### PR TITLE
[하민] 프린터 큐

### DIFF
--- a/02-data-structure-stack-queue-map/1966/hamin.js
+++ b/02-data-structure-stack-queue-map/1966/hamin.js
@@ -1,0 +1,61 @@
+const input = require('fs').readFileSync('/dev/stdin').toString().trim().split('\n');
+
+class Queue {
+  constructor() {
+    this.queue = [];
+    this.front = 0;
+    this.rear = 0;
+  }
+
+  enqueue(value) {
+    this.queue[this.rear++] = value;
+  }
+
+  dequeue() {
+    const value = this.queue[this.front];
+    delete this.queue[this.front];
+    this.front += 1;
+    return value;
+  }
+
+  peek() {
+    return this.queue[this.front];
+  }
+
+  size() {
+    return this.rear - this.front;
+  }
+};
+
+let [_, ...arr] = input;
+arr = arr.map((item) => item.split(' ').map(Number));
+
+for (let i = 0; i < arr.length; i += 2) {
+  const queue = new Queue();
+
+  let cnt = 0;
+  let printArr = arr[i + 1];
+  let location = arr[i][1];
+
+  printArr.forEach((element, idx) =>
+    queue.enqueue([element, idx])
+  );
+
+  printArr.sort((a, b) => b - a);
+
+  while (queue.size() > 0) {
+    let currentValue = queue.peek();
+
+    if (currentValue[0] < printArr[cnt]) {
+      queue.enqueue(queue.dequeue());
+    } else {
+      const value = queue.dequeue();
+      cnt += 1;
+
+      if (location === value[1]) {
+        console.log(cnt);
+        break;
+      }
+    }
+  }
+};


### PR DESCRIPTION
현재 queue에 가장 앞에 있는 문서보다 중요도가 높은 문서가 있으면 queue에 가장 끝으로 재배치 한다.
- queue에 저장할 때 배열의 형태로 [중요도, index]로 저장하고
- sort 메서드로 기존 순서 배열을 내림차순으로 정렬한 뒤에 비교하며 index 값이 location과 동일하면 출력되도록 로직을 작성했습니다.
