### PR TITLE
[대은] 미로 탐색

### DIFF
--- a/03-dfs-bfs-graph/Acisliver.java
+++ b/03-dfs-bfs-graph/Acisliver.java
@@ -1,0 +1,64 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+
+// https://www.acmicpc.net/problem/2178
+// 미로 탐색
+public class Main {
+
+    private static int n, m;
+    private static int[] DX = new int[]{0, 0, -1, 1};
+    private static int[] DY = new int[]{-1, 1, 0, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] input = br.readLine().split(" ");
+        n = Integer.parseInt(input[0]);
+        m = Integer.parseInt(input[1]);
+        int[][] miro = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+            String s = br.readLine();
+            for (int j = 0; j < m; j++) {
+                miro[i][j] = s.charAt(j) - '0';
+
+            }
+        }
+
+        bfs(miro);
+
+        System.out.println(miro[n-1][m-1]);
+    }
+
+    // (0, 0)부터 bfs
+    private static void bfs(int[][] miro) {
+        Queue<int[]> queue = new LinkedList<>();
+        boolean[][] visited = new boolean[n][m];
+        queue.add(new int[]{0, 0});
+        visited[0][0] = true;
+
+        while (!queue.isEmpty()) {
+            int[] cur = queue.poll();
+            int curX = cur[0];
+            int curY = cur[1];
+            for (int i = 0; i < 4; i++) {
+                int nextX = curX + DX[i];
+                int nextY = curY + DY[i];
+
+                if (nextX < 0 || nextY < 0 || nextX >= n || nextY >= m)
+                    continue;
+                if (visited[nextX][nextY] || miro[nextX][nextY] == 0)
+                    continue;
+
+                queue.add(new int[]{nextX, nextY});
+                visited[nextX][nextY] = true;
+                miro[nextX][nextY] = miro[curX][curY] + 1;
+            }
+        }
+
+    }
+}
+


### PR DESCRIPTION
## 풀이

BFS를 사용하여 풀었습니다. BFS 도중 (N, M)에 도달하면 그 경우가 가장 짧은 경우이기 때문에 바로 해당 위치까지 걸린 거리를 바로 정답으로 반환했습니다. 이때 거리를 계산하기 위해 현재 탐색 레벨을 큐에 같이 넣었습니다.