### PR TITLE
[대은] 통증(2)

### DIFF
--- a/06-DP-LIS-BitMask/195693/Acisliver.java
+++ b/06-DP-LIS-BitMask/195693/Acisliver.java
@@ -1,0 +1,38 @@
+package groom;
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    static int N;
+    static int[] ITEMS;
+    static int[] DP;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        ITEMS = Arrays.stream(br.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+        DP = new int[N + 1];
+        Arrays.fill(DP, 123456789);
+        DP[0] = 0;
+
+        for (int i = 1; i <= N; i++) {
+            for (int item : ITEMS) {
+                if (i >= item) {
+                    DP[i] = Math.min(DP[i - item] + 1, DP[i]);
+                }
+            }
+        }
+
+        if (DP[N] == 123456789) {
+            System.out.println(-1);
+            return;
+        }
+
+        System.out.println(DP[N]);
+    }
+}
+
+


### PR DESCRIPTION
## 풀이

동적프로그래밍으로 풀었습니다. 1차원 배열(DP)을 사용했고 DP[i]는 i만큼의 고통을 줄이기 위한 아이템의 **최소 개수**를 의미합니다.
따라서 DP[0]은 0으로 초기화 하고, 나머지 요소는 무한대(123456789)로  초기화 했습니다.

두 아이템의 통증 수치 감소치를 a,  b라 했을 때 `DP[i] = Math.min(DP[i - a] + 1, DP[i - b] + 1)`이 됩니다.
