### PR TITLE
[규진] 작은 노드

### DIFF
--- a/03-dfs-bfs-graph/195696/gyujin.java
+++ b/03-dfs-bfs-graph/195696/gyujin.java
@@ -1,0 +1,54 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+	private static boolean[] visited;
+	private static ArrayList<Integer>[] list;
+	private static int cnt = 1;
+	private static int lastNode;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+		
+		visited = new boolean[N + 1];
+		list = new ArrayList[N + 1];
+		lastNode = K;
+		
+		for (int i = 1; i <= N; i++) {
+			list[i] = new ArrayList<>();
+		}
+		
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int s = Integer.parseInt(st.nextToken());
+			int e = Integer.parseInt(st.nextToken());
+			list[s].add(e);
+			list[e].add(s);
+		}
+		
+		for (int i = 1; i <= N; i++) {
+			Collections.sort(list[i]);
+		}
+		
+		dfs(K);
+		System.out.println(cnt + " " + lastNode);
+	}
+	
+	private static void dfs(int node) {
+		visited[node] = true;
+		
+		for (int new_node : list[node]) {
+			if (!visited[new_node]) {
+				cnt++;
+				lastNode = new_node;
+				dfs(new_node);
+				break;
+			}
+		}
+	}
+	
+}


### PR DESCRIPTION
## 풀이

인접리스트를 이용하여 노드들을 연결시켜주고, 연결된 리스트들을 오름차순 정렬하였습니다.
DFS 탐색을 이용해서 시작노드로부터 연결된 가장 작은 노드들을 타고 들어갔습니다.