### PR TITLE
[규진] 연합

### DIFF
--- a/03-dfs-bfs-graph/195698/gyujin.java
+++ b/03-dfs-bfs-graph/195698/gyujin.java
@@ -1,0 +1,56 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+	private static ArrayList<Integer>[] list;
+	private static boolean[] visited;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		list = new ArrayList[N + 1];
+		visited = new boolean[N + 1];
+		
+		for (int i = 1; i <= N; i++) {
+			list[i] = new ArrayList<>();
+		}
+		
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int s = Integer.parseInt(st.nextToken());
+			int e = Integer.parseInt(st.nextToken());
+			
+			list[s].add(e);
+			// list[e].add(s);
+		}
+		
+		int cnt = 0;
+		for (int i = 1; i <= N; i++) {
+			if (!visited[i]) {
+				unionIsle(i);
+				cnt++;
+			}
+		}
+		
+	System.out.println(cnt);
+	}
+	private static void unionIsle(int node) {
+		Queue<Integer> queue = new LinkedList<>();
+		queue.add(node);
+		visited[node] = true;
+		
+		while(!queue.isEmpty()) {
+			int new_node = queue.poll();
+			for (int i : list[new_node]) {
+				if (!visited[i] && list[i].contains(new_node)) {
+					visited[i] = true;
+					queue.add(i);
+				}
+			}
+		}
+	}
+	
+}


### PR DESCRIPTION
## 풀이

인접리스트를 이용하여 BFS로 탐색하여 연합 갯수를 찾았습니다.
이전과 다른건. 인접리스트로 노드끼리 연결시켜줄때 이전에는 양방향 문제만을 풀어서
인접리스트로 노드 각각 연결을 시켜주었는데, 
이번문제는 단방향으로 연결해줘야하는 점 그리고 탐색하는 로직에서 
반대방향과 연결이 되어있는지를 확인하는 점을 추가하여 해결하였습니다.  
