### PR TITLE
[국인] 그래프 밀집도

### DIFF
--- a/03-dfs-bfs-graph/195699/gukin-han.java
+++ b/03-dfs-bfs-graph/195699/gukin-han.java
@@ -1,0 +1,109 @@
+import java.io.*;
+import java.util.*;
+class Main {
+    private static int N, M;
+    private static List<Component> components = new ArrayList<>();
+    private static List<List<Integer>> adjArr = new ArrayList<>();
+    private static boolean[] visited;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer line = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(line.nextToken());
+        M = Integer.parseInt(line.nextToken());
+        visited = new boolean[N + 1];
+
+        for (int i = 0; i < N + 1; i++) {
+            adjArr.add(new ArrayList<Integer>());
+        }
+
+        for (int i = 0; i < M; i++) {
+            line = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(line.nextToken());
+            int b = Integer.parseInt(line.nextToken());
+
+            adjArr.get(a).add(b);
+            adjArr.get(b).add(a);
+        }
+
+        for (int node = 1; node < N; node++){
+            if (visited[node]) continue;
+            Component component = new Component(node);
+            int numLink = findLink(node, component);
+            Collections.sort(component.computers);
+            component.lineNum = numLink/2;
+            component.minNum = component.computers.get(0) + 1;
+            component.density = component.lineNum / (double) component.size;
+            components.add(component);
+        }
+
+        Collections.sort(components);
+        System.out.println(components.get(0).toString());
+    }
+
+    private static int findLink(int node, Component component) {
+        Queue<Integer> q = new LinkedList<>();
+        q.add(node);
+        int numLink = 0;
+
+        while(!q.isEmpty()) {
+            int from = q.poll();
+//            component.add(from);
+            visited[from] = true;
+
+            for (int to: adjArr.get(from)) {
+                numLink++;
+                if (visited[to]) continue;
+                component.add(to);
+                visited[to] = true;
+                q.add(to);
+            }
+        }
+        return numLink;
+    }
+
+    private static class Component implements Comparable<Component>{
+        public List<Integer> computers = new ArrayList<>();
+        public long size = 0;
+        public long minNum = Integer.MAX_VALUE;
+        public long lineNum;
+        public double density;
+
+        public Component(int node) {
+            computers.add(node);
+            size++;
+            lineNum = 0;
+            density = 0;
+        }
+
+        public void add(Integer computer) {
+//            if (!computers.contains(computer)) {
+                computers.add(computer);
+                size = computers.size();
+//            }
+            lineNum++;
+        }
+
+        @Override
+        public int compareTo(Component o) {
+            if (this.density != o.density) {
+                if (this.density < o.density) return 1;
+                else return -1;
+            } else {
+                if (this.size != o.size) {
+                    return (int) (this.size - o.size);
+                } else {
+                    return (int) ( this.minNum - o.minNum);
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            for (int computer: computers) {
+                sb.append(computer).append(" ");
+            }
+            return sb.toString();
+        }
+    }
+}


### PR DESCRIPTION
## 풀이

- component 클래스를 만들어서, 비교 기준을 그대로 적용했습니다. 
- bfs에서 빠져나오면, 연결 개수, 최소값, 밀도를 다시 밀어넣어서 정렬하여 출력했습니다.
- 출력은 toString을 오버라이드 했습니다.
- 실수가 많아서 계속 고치면서 했습니다.
   - 실수 1: 처음에 o, this를 반대로 해서 다시 수정했습니다.
   - 실수 2: 연결 개수를 카운트할때, 불필요한 개수도 카운트 되어 수정했습니다.
- 시간 복잡도를 최적화했습니다.
- 중복 방지를 component 내부에 add 메서드로 구현했는데, contain 메서드를 자주 사용하면서 시간 복잡도가 커지는것을 확인했습니다. 
- contain을 주석처리하고, bfs 내부에서 O(1)으로 중복 처리 했습니다.
