### PR TITLE
[규진] 대체 경로

### DIFF
--- a/03-dfs-bfs-graph/195701/gyujin.java
+++ b/03-dfs-bfs-graph/195701/gyujin.java
@@ -1,0 +1,65 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+	private static ArrayList<Integer>[] list;
+	private static boolean[] visited;
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		int S = Integer.parseInt(st.nextToken());
+		int E = Integer.parseInt(st.nextToken());
+		
+		list = new ArrayList[N + 1];
+		for (int i = 1; i <= N; i++) {
+			list[i] = new ArrayList<>();
+		}
+		
+		for (int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int u = Integer.parseInt(st.nextToken());
+			int v = Integer.parseInt(st.nextToken());
+			
+			list[u].add(v);
+			list[v].add(u);
+		}
+		
+		for (int i = 1; i <= N; i++) {
+			visited = new boolean[N + 1];
+			visited[i] = true;
+			sb.append(bfs(S, E)).append('\n');
+			visited[i] = false;
+		}
+		
+		System.out.println(sb);
+	}
+	private static int bfs(int startNode, int endNode) {
+		if (visited[startNode]) return -1;
+				
+		Queue<Integer> queue = new LinkedList<>();
+		queue.add(startNode);
+		
+		int[] nodeCnt = new int[visited.length];
+		nodeCnt[startNode] = 1;
+		
+		while (!queue.isEmpty()) {
+			int nextNode = queue.poll();
+			for (int i : list[nextNode]) {
+				if (!visited[i]) {
+					visited[i] = true;
+					nodeCnt[i] = nodeCnt[nextNode] + 1;
+					queue.add(i);
+					if (i == endNode) {
+						return nodeCnt[i];
+					}
+				}
+			}
+		}
+		
+		return -1;
+	}
+}


### PR DESCRIPTION
## 풀이

인접리스트로 노드들을 양방향 연결시켜주고,
i번째 출력때 i번 노드는 공사중이니 i번일때 방문한 것으로 하고,
bfs 탐색을 합니다. 그리고 매번 공사중인 노드는 바뀌니 
매번 방문한 배열은 초기화를 시켜주었습니다.
그리고 너비우선탐색이니 배열을 이용해서 탐색한 노드에서 다음 노드의 거리는 +1로 고루 분배해주어서
결과를 도출하였습니다.
