### PR TITLE
[규진] 1로 만들기

### DIFF
--- a/06-DP-LIS-BitMask/1463/gyujin.java
+++ b/06-DP-LIS-BitMask/1463/gyujin.java
@@ -1,0 +1,28 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int X = Integer.parseInt(br.readLine());
+
+        int[] dp = new int[X + 1];
+
+        for (int i = 1; i < X; i++) {
+            dp[i] = X + 1;
+        }
+
+        for (int i = X; 0 < i; i--) {
+            if (i % 3 == 0) {
+                dp[i / 3] = Math.min(dp[i / 3], dp[i] + 1);
+            }
+            if (i % 2 == 0) {
+                dp[i / 2] = Math.min(dp[i / 2], dp[i] + 1);
+            }
+            dp[i - 1] = Math.min(dp[i - 1], dp[i] + 1);
+        }
+
+        System.out.println(dp[1]);
+    }
+}


### PR DESCRIPTION
## 풀이

주어진 정수 X+1 크기의 dp배열을 만들어 각 인덱스를 X + 1로 초기화시켜 최솟값을 비교할때 문제가 없도록 했습니다.
X번 인덱스부터 조건에 따라 비교하여 해당 배열에 최솟값을 넣어 결국 인덱스 1번까지 도달할 때
가장 최솟값이 들어가도록 하였습니다.