### PR TITLE
[규진] 동전

### DIFF
--- a/06-DP-LIS-BitMask/9084/gyujin.java
+++ b/06-DP-LIS-BitMask/9084/gyujin.java
@@ -1,0 +1,33 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+
+        for (int test_case = 1; test_case <= T; test_case++) {
+            int N = Integer.parseInt(br.readLine());
+            int[] money = new int[N];
+
+            st = new StringTokenizer(br.readLine());
+            for (int i = 0; i < N; i++) {
+                money[i] = Integer.parseInt(st.nextToken());
+            }
+            int M = Integer.parseInt(br.readLine());
+            int[] dp = new int[M + 1];
+
+            dp[0] = 1;
+
+            for (int i = 0; i < N; i++) {
+                for (int j = money[i]; j <= M; j++) {
+                    dp[j] += dp[j - money[i]];
+                }
+            }
+
+            System.out.println(dp[M]);
+        }
+    }
+}


### PR DESCRIPTION
## 풀이

처음으로 생각했던 대로 구현하면 동전이 겹치는 경우의 수들이 나와 횟수들이 중복되서 나오는것을 해결하는게 어려웠습니다.
동전의 가지 수를 제한하여 동전은 딱 한번씩만 호출하여 기존에 나왔던 경우의 수들로부터 계속 이어나가
결과값을 출력하였습니다.