### PR TITLE
[대은] 동전

### DIFF
--- a/06-DP-LIS-BitMask/9084/Acisliver.java
+++ b/06-DP-LIS-BitMask/9084/Acisliver.java
@@ -1,0 +1,40 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+import static java.lang.System.in;
+
+// 동전
+// https://www.acmicpc.net/problem/9084
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        int T = Integer.parseInt(br.readLine());
+
+        while (T-- > 0) {
+            int N = Integer.parseInt(br.readLine());
+            int[] coins = Arrays.stream(br.readLine().split(" "))
+                    .mapToInt(Integer::parseInt)
+                    .toArray();
+            int M = Integer.parseInt(br.readLine());
+            int count = getCount(M, coins);
+            System.out.println(count);
+        }
+    }
+
+    private static int getCount(int money, int[] coins) {
+        int[] memo = new int[money + 1];
+        memo[0] = 1;
+
+        for (int coin : coins) {
+            for (int i = coin; i <= money; i++) {
+                memo[i] += memo[i - coin];
+            }
+        }
+
+        return memo[money];
+    }
+}
+


### PR DESCRIPTION
## 풀이

DP로 해결했습니다. 
처음에 배낭문제처럼 2차원 배열로 접근했지만 굳이 그럴 필요가 없어서 1차원 배열로 변경했습니다.
첫 번째 동전으로 만들 수 있는 숫자의 경우의 수를 구하고 이것을 N번째 동전까지 반복합니다. 이를 반복문으로 구현합니다.
i번째 반복은 1~i번째 동전으로 j 금액을 만들는 경우의 수 입니다.
따라서 점화식은
`DP[i] = DP[i - coins[j]]`  가 되고 이를 동전마다 반복하고 누적해주면 됩니다.
