### PR TITLE
[국인] 가장 긴 증가하는 부분 수열

### DIFF
--- a/06-DP-LIS-BitMask/11053/gukin-han.java
+++ b/06-DP-LIS-BitMask/11053/gukin-han.java
@@ -1,0 +1,27 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] A = Arrays
+                .stream(br.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+
+        int[] dp = new int[A.length];
+        dp[0] = 1;
+        for (int i = 1; i < dp.length; i++) {
+            int max = 0;
+            for (int j = 0; j < i ; j++) {
+                if (A[j] < A[i] && dp[j] > max) {
+                    max = dp[j];
+                }
+            }
+            dp[i] = max + 1;
+        }
+        int answer = Arrays.stream(dp).max().getAsInt();
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
## 풀이

- 현재 값보다 작은 값 중에서 가장 긴 부분 수열 수를 가진 값에 +1을 하면
- 시간 복잡도 O(n^2)으로 구현할 수 있습니다.
