### PR TITLE
[규진] 가장 긴 증가하는 부분 수열

### DIFF
--- a/06-DP-LIS-BitMask/11053/gyujin.java
+++ b/06-DP-LIS-BitMask/11053/gyujin.java
@@ -1,0 +1,29 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        int[] A = new int[N];
+        int[] dp = new int[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            A[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int result = 1;
+        for (int i = 0; i < N; i++) {
+            dp[i] = 1;
+            for (int j = 0; j < i; j++) {
+                if (A[j] < A[i]) {
+                    dp[i] = Math.max(dp[i], dp[j] + 1);
+                    result = Math.max(result, dp[i]);
+                }
+            }
+        }
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 풀이

가장 긴 부분 수열이 자기 자신 길이인 1일 수 있으니, 기준이 되는 수 차례때마다 1로 초기화를 시켜주고,
기준이 되는 수 이전만큼 for문을 차례대로 돌려 기준보다 더 작다면, 
더 작은 아이가 가지고 있던 길이 + 1(기준)  과 1(기준) 에서 더 큰 값을 기준한테 넣는 방식으로 해결하였습니다.