### PR TITLE
[규진] 가장 큰 정사각형

### DIFF
--- a/06-DP-LIS-BitMask/1915/gyujin.java
+++ b/06-DP-LIS-BitMask/1915/gyujin.java
@@ -1,0 +1,28 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int[][] square = new int[n + 1][m + 1];
+        int[][] dp = new int[n + 1][m + 1];
+        int max = 0;
+
+        for (int i = 1; i <= n; i++) {
+            String num = br.readLine();
+            for (int j = 1; j <= m; j++) {
+                square[i][j] = Integer.parseInt(num.substring(j - 1,j));
+                if (square[i][j] == 1) {
+                    dp[i][j] = Math.min(dp[i - 1][j - 1], Math.min(dp[i - 1][j], dp[i][j - 1])) + 1;
+                    max = Math.max(max, dp[i][j]);
+                }
+            }
+        }
+
+        System.out.println(max * max);
+    }
+}


### PR DESCRIPTION
## 풀이

입력받은 배열에서 1을 만나면 dp배열에 반영을 하는데, 그 1은 정사각형의 맨오른쪽 모서리라고 생각하고 
1을 기준으로 왼쪽, 위쪽, 왼쪽 대각선 이 세가지를 비교하여 가장 작은 값의 + 1을 dp배열에 넣어줍니다.
그래서 dp배열에서 가장 큰 값에서 제곱을 하여 정사각형 넓이를 출력하였습니다.
