### PR TITLE
[규진] 사탕 가게

### DIFF
--- a/06-DP-LIS-BitMask/4781/gyujin.java
+++ b/06-DP-LIS-BitMask/4781/gyujin.java
@@ -1,0 +1,32 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        while (true) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int n = Integer.parseInt(st.nextToken());
+//            int m = (int)(Double.parseDouble(st.nextToken()) * 100 + 0.5);
+            int m = (int)Math.round(Double.parseDouble(st.nextToken()) * 100);
+            if (n == 0 && m == 0) break;
+            int[] dp = new int[m + 1];
+
+            for (int i = 0; i < n; i++) {
+                st = new StringTokenizer(br.readLine());
+                int c = Integer.parseInt(st.nextToken());
+//                int p = (int)Math.round(Double.parseDouble(st.nextToken()) * 100);
+                int p = (int)(Double.parseDouble(st.nextToken()) * 100 + 0.5);
+
+                for (int j = p; j <= m; j++) {
+                    dp[j] = Math.max(dp[j], dp[j - p] + c);
+                }
+            }
+
+            sb.append(dp[m]).append('\n');
+        }
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
## 풀이

이전에 풀었던 knapsack 문제와의 차이점은 선택한 개수에 따른 최댓값이 아닌 중복해서 고를 수 있다는 점이었습니다.
그래서 동일하게 최대액수만큼 dp 배열크기를 생성해주고, for문을 이용해서 이전값과 현재값을 비교해주어 최댓값을 넣어주었습니다.
+
소수가 나오는 문제면 항상 무섭습니다.
이번 문제는 부동소수점 수를 정수로 변환할 때, 생각했던 수와 오차가 발생할 수 있어
반올림과 +0.5를 더해주는 방법을 배웠습니다.
