### PR TITLE
[규진] 1897. Redistribute Characters to Make All Strings Equal

### DIFF
--- a/Leetcode/1897/gyujin.java
+++ b/Leetcode/1897/gyujin.java
@@ -1,0 +1,20 @@
+class Solution {
+    public boolean makeEqual(String[] words) {
+        int wordsLen = words.length;
+        int[] usedAlpha = new int[26];
+
+          for (String word : words) {
+              for (char c : word.toCharArray()) {
+                  usedAlpha[c - 'a']++;
+              }
+          }
+
+          for (int a : usedAlpha) {
+              if (a % wordsLen != 0) {
+                  return false;
+              }
+          }
+         
+        return true;
+    }
+}


### PR DESCRIPTION
## 풀이

배열 원소들의 각 알파벳 갯수가 배열의 길이만큼 있어야 하는 것을 이용했습니다.